### PR TITLE
Implement new color game mode and navigation

### DIFF
--- a/app/composables/useSettings.js
+++ b/app/composables/useSettings.js
@@ -14,6 +14,7 @@ const difficulty = ref('easy') // reserved for future use
 const challengesEnabled = ref(true)
 const debugEnabled = ref(false)
 const bgVolume = ref(0.25)
+const gameMode = ref('numbers')
 
 function safeGet(key, fallback) {
     if (!isClient) return fallback
@@ -42,6 +43,8 @@ function ensureInit() {
     debugEnabled.value = safeGet('debugEnabled', 'false') === 'true'
     const savedBgVol = parseFloat(safeGet('bgVolume', '0.25'))
     bgVolume.value = Number.isFinite(savedBgVol) ? Math.max(0, Math.min(1, savedBgVol)) : 0.25
+    const savedMode = safeGet('gameMode', 'numbers')
+    gameMode.value = ['numbers', 'colors'].includes(savedMode) ? savedMode : 'numbers'
 
     // Persist on change
     watch(soundOn, v => safeSet('soundOn', Boolean(v)))
@@ -50,6 +53,7 @@ function ensureInit() {
     watch(challengesEnabled, v => safeSet('challengesEnabled', Boolean(v)))
     watch(debugEnabled, v => safeSet('debugEnabled', Boolean(v)))
     watch(bgVolume, v => safeSet('bgVolume', Math.max(0, Math.min(1, Number(v)))))
+    watch(gameMode, v => safeSet('gameMode', v))
 
     initialized.value = true
 }
@@ -63,6 +67,7 @@ export function useSettings() {
         challengesEnabled,
         debugEnabled,
         bgVolume,
+        gameMode,
     }
 }
 

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,6 +1,13 @@
 <template>
     <div class="main">
         <div class="w-full h-full flex flex-col items-center justify-center gap-8">
+            <div class="flex flex-col items-center gap-2">
+                <label for="game-mode" class="text-black font-semibold">Game mode</label>
+                <select id="game-mode" v-model="gameMode" class="input-orange !py-1 !px-2">
+                    <option value="numbers">Numbers</option>
+                    <option value="colors">Colors</option>
+                </select>
+            </div>
             <NuxtLink to="/play" class="relative group" @click="onClickPlay">
                 <span class="sr-only">Play</span>
                 <div class="absolute inset-0 z-0 button-orange rounded-full opacity-40 animate-ping"></div>
@@ -13,6 +20,7 @@
 <script setup>
 const { unlock } = useSound()
 const { prepare } = useHaptics()
+const { gameMode } = useSettings()
 
 function onClickPlay() {
     if (import.meta.client) {


### PR DESCRIPTION
Add a new 'colors' game mode with a selection dropdown on the landing page and a long-press back button in gameplay.

---
<a href="https://cursor.com/background-agent?bcId=bc-92aab6f0-8681-4f8f-9628-f262ac90b2f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-92aab6f0-8681-4f8f-9628-f262ac90b2f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

