### PR TITLE
Ensure color tile background and no text

### DIFF
--- a/app/pages/play.vue
+++ b/app/pages/play.vue
@@ -9,7 +9,6 @@
                          class="basis-[calc((100%-theme(space.4)*2)/3)] aspect-square border-4 border-orange rounded-lg flex items-center justify-center cursor-pointer select-none"
                          :class="[tile.bgClass, tile.textClass]" @pointerdown="onTileDown(tile)" :aria-label="tile.ariaLabel">
                         <span v-if="gameMode === 'numbers'" class="text-4xl font-bold text-orange">{{ tile.number }}</span>
-                        <span v-else class="text-2xl font-bold">{{ tile.label }}</span>
                         <span class="sr-only">{{ tile.ariaLabel }}</span>
                     </div>
                 </div>


### PR DESCRIPTION
Remove visible text from color game tiles to align with the 'colors' game mode design.

---
<a href="https://cursor.com/background-agent?bcId=bc-a86fffa5-fc74-4784-89df-0b7552d0971b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a86fffa5-fc74-4784-89df-0b7552d0971b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

