### PR TITLE
Fix color game mode tile backgrounds

### DIFF
--- a/app/pages/play.vue
+++ b/app/pages/play.vue
@@ -7,7 +7,7 @@
                 <div class="flex flex-wrap items-center justify-center w-full max-w-sm gap-4">
                     <div tabindex="0" v-for="tile in tiles" :key="tile.id"
                          class="basis-[calc((100%-theme(space.4)*2)/3)] aspect-square border-4 border-orange rounded-lg flex items-center justify-center cursor-pointer select-none"
-                         :class="[tile.bgClass, tile.textClass]" @pointerdown="onTileDown(tile)" :aria-label="tile.ariaLabel">
+                         :class="[tile.bgClass, tile.textClass]" :style="tile.bgStyle" @pointerdown="onTileDown(tile)" :aria-label="tile.ariaLabel">
                         <span v-if="gameMode === 'numbers'" class="text-4xl font-bold text-orange">{{ tile.number }}</span>
                         <span class="sr-only">{{ tile.ariaLabel }}</span>
                     </div>
@@ -133,7 +133,8 @@ const tiles = computed(() => {
         colorName: c,
         ariaLabel: `${colorNames[c].en} / ${colorNames[c].nl}`,
         label: `${colorNames[c].en} / ${colorNames[c].nl}`,
-        bgClass: `bg-game-${c}`,
+        bgClass: '',
+        bgStyle: { backgroundColor: `var(--color-game-${c})` },
         textClass: getTileTextClass(c),
     }))
 })


### PR DESCRIPTION
Use inline CSS variables for color game tile backgrounds to ensure correct display.

---
<a href="https://cursor.com/background-agent?bcId=bc-12afc5a2-d978-4b55-9107-5eaaccad6c18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-12afc5a2-d978-4b55-9107-5eaaccad6c18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

