### PR TITLE
Add animal game mode with learning tiles

### DIFF
--- a/app/composables/useSettings.js
+++ b/app/composables/useSettings.js
@@ -44,7 +44,7 @@ function ensureInit() {
     const savedBgVol = parseFloat(safeGet('bgVolume', '0.25'))
     bgVolume.value = Number.isFinite(savedBgVol) ? Math.max(0, Math.min(1, savedBgVol)) : 0.25
     const savedMode = safeGet('gameMode', 'numbers')
-    gameMode.value = ['numbers', 'colors'].includes(savedMode) ? savedMode : 'numbers'
+    gameMode.value = ['numbers', 'colors', 'animals'].includes(savedMode) ? savedMode : 'numbers'
 
     // Persist on change
     watch(soundOn, v => safeSet('soundOn', Boolean(v)))

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -6,6 +6,7 @@
                 <select id="game-mode" v-model="gameMode" class="input-orange !py-1 !px-2">
                     <option value="numbers">Numbers</option>
                     <option value="colors">Colors</option>
+                    <option value="animals">Animals</option>
                 </select>
             </div>
             <NuxtLink to="/play" class="relative group" @click="onClickPlay">

--- a/public/assets/animals/animals.json
+++ b/public/assets/animals/animals.json
@@ -1,0 +1,16 @@
+{
+	"animals": [
+		{ "key": "cat", "src": "/assets/animals/cat.svg", "en": "cat", "nl": "kat" },
+		{ "key": "dog", "src": "/assets/animals/dog.svg", "en": "dog", "nl": "hond" },
+		{ "key": "cow", "src": "/assets/animals/cow.svg", "en": "cow", "nl": "koe" },
+		{ "key": "horse", "src": "/assets/animals/horse.svg", "en": "horse", "nl": "paard" },
+		{ "key": "sheep", "src": "/assets/animals/sheep.svg", "en": "sheep", "nl": "schaap" },
+		{ "key": "pig", "src": "/assets/animals/pig.svg", "en": "pig", "nl": "varken" },
+		{ "key": "lion", "src": "/assets/animals/lion.svg", "en": "lion", "nl": "leeuw" },
+		{ "key": "tiger", "src": "/assets/animals/tiger.svg", "en": "tiger", "nl": "tijger" },
+		{ "key": "elephant", "src": "/assets/animals/elephant.svg", "en": "elephant", "nl": "olifant" },
+		{ "key": "monkey", "src": "/assets/animals/monkey.svg", "en": "monkey", "nl": "aap" },
+		{ "key": "bird", "src": "/assets/animals/bird.svg", "en": "bird", "nl": "vogel" },
+		{ "key": "fish", "src": "/assets/animals/fish.svg", "en": "fish", "nl": "vis" }
+	]
+}

--- a/public/assets/animals/bird.svg
+++ b/public/assets/animals/bird.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+	<rect width="100" height="100" rx="16" fill="#E3F2FD"/>
+	<circle cx="50" cy="55" r="22" fill="#87CEEB"/>
+	<circle cx="44" cy="52" r="4" fill="#000"/>
+	<polygon points="58,55 70,50 58,45" fill="#FFA000"/>
+</svg>

--- a/public/assets/animals/cat.svg
+++ b/public/assets/animals/cat.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+	<rect width="100" height="100" rx="16" fill="#FFEFD5"/>
+	<circle cx="50" cy="55" r="28" fill="#F4A460"/>
+	<circle cx="40" cy="50" r="5" fill="#000"/>
+	<circle cx="60" cy="50" r="5" fill="#000"/>
+	<path d="M35 70 Q50 80 65 70" stroke="#000" stroke-width="3" fill="none"/>
+	<polygon points="30,35 40,20 45,38" fill="#F4A460"/>
+	<polygon points="70,35 60,20 55,38" fill="#F4A460"/>
+</svg>

--- a/public/assets/animals/cow.svg
+++ b/public/assets/animals/cow.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+	<rect width="100" height="100" rx="16" fill="#F0FFF0"/>
+	<circle cx="50" cy="55" r="28" fill="#fff"/>
+	<circle cx="40" cy="50" r="5" fill="#000"/>
+	<circle cx="60" cy="50" r="5" fill="#000"/>
+	<path d="M35 70 Q50 82 65 70" stroke="#000" stroke-width="3" fill="none"/>
+	<rect x="28" y="40" width="12" height="10" fill="#000"/>
+	<rect x="60" y="42" width="10" height="8" fill="#000"/>
+</svg>

--- a/public/assets/animals/dog.svg
+++ b/public/assets/animals/dog.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+	<rect width="100" height="100" rx="16" fill="#E6F7FF"/>
+	<circle cx="50" cy="55" r="28" fill="#C2B280"/>
+	<circle cx="40" cy="50" r="5" fill="#000"/>
+	<circle cx="60" cy="50" r="5" fill="#000"/>
+	<path d="M35 70 Q50 78 65 70" stroke="#000" stroke-width="3" fill="none"/>
+	<rect x="25" y="35" width="12" height="10" rx="4" fill="#C2B280"/>
+	<rect x="63" y="35" width="12" height="10" rx="4" fill="#C2B280"/>
+</svg>

--- a/public/assets/animals/elephant.svg
+++ b/public/assets/animals/elephant.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+	<rect width="100" height="100" rx="16" fill="#EEF3F8"/>
+	<circle cx="50" cy="55" r="28" fill="#B0C4DE"/>
+	<circle cx="40" cy="50" r="5" fill="#000"/>
+	<circle cx="60" cy="50" r="5" fill="#000"/>
+	<rect x="46" y="58" width="8" height="16" rx="4" fill="#B0C4DE"/>
+</svg>

--- a/public/assets/animals/fish.svg
+++ b/public/assets/animals/fish.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+	<rect width="100" height="100" rx="16" fill="#E0F7FA"/>
+	<ellipse cx="52" cy="55" rx="22" ry="14" fill="#00BCD4"/>
+	<polygon points="30,55 18,48 18,62" fill="#00ACC1"/>
+	<circle cx="58" cy="52" r="3" fill="#000"/>
+</svg>

--- a/public/assets/animals/horse.svg
+++ b/public/assets/animals/horse.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+	<rect width="100" height="100" rx="16" fill="#FFF5E6"/>
+	<circle cx="50" cy="55" r="28" fill="#8B4513"/>
+	<circle cx="40" cy="50" r="5" fill="#000"/>
+	<circle cx="60" cy="50" r="5" fill="#000"/>
+	<path d="M35 70 Q50 85 65 70" stroke="#000" stroke-width="3" fill="none"/>
+	<polygon points="30,40 45,30 42,45" fill="#8B4513"/>
+	<polygon points="70,40 55,30 58,45" fill="#8B4513"/>
+</svg>

--- a/public/assets/animals/lion.svg
+++ b/public/assets/animals/lion.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+	<rect width="100" height="100" rx="16" fill="#FFF8E1"/>
+	<circle cx="50" cy="55" r="28" fill="#DAA520"/>
+	<circle cx="50" cy="55" r="22" fill="#F4A460"/>
+	<circle cx="43" cy="52" r="4" fill="#000"/>
+	<circle cx="57" cy="52" r="4" fill="#000"/>
+	<path d="M40 68 Q50 75 60 68" stroke="#000" stroke-width="3" fill="none"/>
+</svg>

--- a/public/assets/animals/monkey.svg
+++ b/public/assets/animals/monkey.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+	<rect width="100" height="100" rx="16" fill="#FFF7E6"/>
+	<circle cx="50" cy="55" r="28" fill="#A0522D"/>
+	<circle cx="50" cy="60" r="16" fill="#CD853F"/>
+	<circle cx="44" cy="56" r="4" fill="#000"/>
+	<circle cx="56" cy="56" r="4" fill="#000"/>
+</svg>

--- a/public/assets/animals/pig.svg
+++ b/public/assets/animals/pig.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+	<rect width="100" height="100" rx="16" fill="#FFE6F0"/>
+	<circle cx="50" cy="55" r="28" fill="#FFC0CB"/>
+	<circle cx="40" cy="50" r="5" fill="#000"/>
+	<circle cx="60" cy="50" r="5" fill="#000"/>
+	<ellipse cx="50" cy="62" rx="10" ry="6" fill="#FF99AA" stroke="#000" stroke-width="2"/>
+</svg>

--- a/public/assets/animals/sheep.svg
+++ b/public/assets/animals/sheep.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+	<rect width="100" height="100" rx="16" fill="#F8F9FA"/>
+	<circle cx="50" cy="55" r="28" fill="#FFFFFF"/>
+	<circle cx="40" cy="50" r="5" fill="#000"/>
+	<circle cx="60" cy="50" r="5" fill="#000"/>
+	<path d="M35 70 Q50 86 65 70" stroke="#000" stroke-width="3" fill="none"/>
+	<circle cx="30" cy="45" r="6" fill="#FFFFFF"/>
+	<circle cx="70" cy="45" r="6" fill="#FFFFFF"/>
+</svg>

--- a/public/assets/animals/tiger.svg
+++ b/public/assets/animals/tiger.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+	<rect width="100" height="100" rx="16" fill="#FFF3E0"/>
+	<circle cx="50" cy="55" r="28" fill="#FF8C00"/>
+	<path d="M30 45 L70 45 M30 55 L70 55 M30 65 L70 65" stroke="#000" stroke-width="3"/>
+	<circle cx="40" cy="50" r="5" fill="#000"/>
+	<circle cx="60" cy="50" r="5" fill="#000"/>
+</svg>


### PR DESCRIPTION
Add a new 'Animals' game mode with 12 animal images and customizable labels to expand educational options.

---
<a href="https://cursor.com/background-agent?bcId=bc-afbdb8b4-40f7-47c1-a337-2cdc5f1a22ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-afbdb8b4-40f7-47c1-a337-2cdc5f1a22ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

