### PR TITLE
Add vehicles game mode

### DIFF
--- a/app/composables/useSettings.js
+++ b/app/composables/useSettings.js
@@ -44,7 +44,7 @@ function ensureInit() {
     const savedBgVol = parseFloat(safeGet('bgVolume', '0.25'))
     bgVolume.value = Number.isFinite(savedBgVol) ? Math.max(0, Math.min(1, savedBgVol)) : 0.25
     const savedMode = safeGet('gameMode', 'numbers')
-    gameMode.value = ['numbers', 'colors', 'animals'].includes(savedMode) ? savedMode : 'numbers'
+    gameMode.value = ['numbers', 'colors', 'animals', 'vehicles'].includes(savedMode) ? savedMode : 'numbers'
 
     // Persist on change
     watch(soundOn, v => safeSet('soundOn', Boolean(v)))

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -7,6 +7,7 @@
                     <option value="numbers">Numbers</option>
                     <option value="colors">Colors</option>
                     <option value="animals">Animals</option>
+                    <option value="vehicles">Vehicles</option>
                 </select>
             </div>
             <NuxtLink to="/play" class="relative group" @click="onClickPlay">

--- a/public/assets/vehicles/airplane.svg
+++ b/public/assets/vehicles/airplane.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+	<rect width="100" height="100" rx="16" fill="#E3F2FD"/>
+	<polygon points="20,60 80,50 20,40" fill="#1E88E5"/>
+	<rect x="30" y="46" width="14" height="8" fill="#90CAF9"/>
+	<rect x="50" y="46" width="10" height="8" fill="#90CAF9"/>
+</svg>

--- a/public/assets/vehicles/bicycle.svg
+++ b/public/assets/vehicles/bicycle.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+	<rect width="100" height="100" rx="16" fill="#F3E5F5"/>
+	<circle cx="30" cy="72" r="10" fill="#7B1FA2"/>
+	<circle cx="70" cy="72" r="10" fill="#7B1FA2"/>
+	<rect x="45" y="60" width="10" height="4" fill="#AB47BC"/>
+	<rect x="38" y="56" width="8" height="4" fill="#AB47BC"/>
+	<rect x="56" y="56" width="8" height="4" fill="#AB47BC"/>
+</svg>

--- a/public/assets/vehicles/boat.svg
+++ b/public/assets/vehicles/boat.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+	<rect width="100" height="100" rx="16" fill="#E0F2F1"/>
+	<polygon points="25,60 75,60 65,70 35,70" fill="#00897B"/>
+	<rect x="45" y="45" width="10" height="12" fill="#4DB6AC"/>
+	<rect x="40" y="40" width="20" height="4" fill="#80CBC4"/>
+</svg>

--- a/public/assets/vehicles/bus.svg
+++ b/public/assets/vehicles/bus.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+	<rect width="100" height="100" rx="16" fill="#FFF3E0"/>
+	<rect x="18" y="45" width="64" height="22" rx="4" fill="#FB8C00"/>
+	<rect x="22" y="48" width="18" height="10" rx="2" fill="#FFE0B2"/>
+	<rect x="44" y="48" width="18" height="10" rx="2" fill="#FFE0B2"/>
+	<rect x="66" y="48" width="12" height="10" rx="2" fill="#FFE0B2"/>
+	<circle cx="30" cy="72" r="6" fill="#000"/>
+	<circle cx="70" cy="72" r="6" fill="#000"/>
+</svg>

--- a/public/assets/vehicles/car.svg
+++ b/public/assets/vehicles/car.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+	<rect width="100" height="100" rx="16" fill="#E0F7FA"/>
+	<rect x="20" y="50" width="60" height="20" rx="6" fill="#0288D1"/>
+	<rect x="30" y="40" width="40" height="12" rx="4" fill="#4FC3F7"/>
+	<circle cx="32" cy="74" r="6" fill="#000"/>
+	<circle cx="68" cy="74" r="6" fill="#000"/>
+</svg>

--- a/public/assets/vehicles/helicopter.svg
+++ b/public/assets/vehicles/helicopter.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+	<rect width="100" height="100" rx="16" fill="#E8EAF6"/>
+	<rect x="30" y="52" width="40" height="12" rx="3" fill="#5C6BC0"/>
+	<rect x="46" y="40" width="8" height="10" fill="#9FA8DA"/>
+	<rect x="35" y="38" width="30" height="4" fill="#7986CB"/>
+	<circle cx="70" cy="68" r="3" fill="#5C6BC0"/>
+</svg>

--- a/public/assets/vehicles/motorcycle.svg
+++ b/public/assets/vehicles/motorcycle.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+	<rect width="100" height="100" rx="16" fill="#FCE4EC"/>
+	<circle cx="32" cy="74" r="8" fill="#C2185B"/>
+	<circle cx="68" cy="74" r="8" fill="#C2185B"/>
+	<rect x="38" y="60" width="24" height="6" rx="2" fill="#F06292"/>
+	<rect x="58" y="56" width="10" height="4" fill="#F06292"/>
+</svg>

--- a/public/assets/vehicles/tractor.svg
+++ b/public/assets/vehicles/tractor.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+	<rect width="100" height="100" rx="16" fill="#E8F5E9"/>
+	<rect x="28" y="50" width="34" height="14" rx="2" fill="#66BB6A"/>
+	<rect x="62" y="54" width="10" height="10" rx="2" fill="#A5D6A7"/>
+	<circle cx="34" cy="72" r="8" fill="#000"/>
+	<circle cx="68" cy="72" r="6" fill="#000"/>
+</svg>

--- a/public/assets/vehicles/train.svg
+++ b/public/assets/vehicles/train.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+	<rect width="100" height="100" rx="16" fill="#FFF8E1"/>
+	<rect x="20" y="48" width="60" height="16" rx="3" fill="#FBC02D"/>
+	<rect x="24" y="50" width="12" height="8" fill="#FFF59D"/>
+	<rect x="38" y="50" width="12" height="8" fill="#FFF59D"/>
+	<rect x="52" y="50" width="12" height="8" fill="#FFF59D"/>
+	<rect x="66" y="50" width="10" height="8" fill="#FFF59D"/>
+	<circle cx="32" cy="68" r="5" fill="#000"/>
+	<circle cx="68" cy="68" r="5" fill="#000"/>
+</svg>

--- a/public/assets/vehicles/truck.svg
+++ b/public/assets/vehicles/truck.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+	<rect width="100" height="100" rx="16" fill="#E8F5E9"/>
+	<rect x="18" y="48" width="42" height="20" rx="3" fill="#43A047"/>
+	<rect x="60" y="52" width="20" height="16" rx="2" fill="#81C784"/>
+	<circle cx="30" cy="74" r="6" fill="#000"/>
+	<circle cx="64" cy="74" r="6" fill="#000"/>
+	<circle cx="76" cy="74" r="6" fill="#000"/>
+</svg>

--- a/public/assets/vehicles/vehicles.json
+++ b/public/assets/vehicles/vehicles.json
@@ -1,0 +1,14 @@
+{
+	"vehicles": [
+		{ "key": "car", "src": "/assets/vehicles/car.svg", "en": "car", "nl": "auto" },
+		{ "key": "bus", "src": "/assets/vehicles/bus.svg", "en": "bus", "nl": "bus" },
+		{ "key": "truck", "src": "/assets/vehicles/truck.svg", "en": "truck", "nl": "vrachtwagen" },
+		{ "key": "bicycle", "src": "/assets/vehicles/bicycle.svg", "en": "bicycle", "nl": "fiets" },
+		{ "key": "motorcycle", "src": "/assets/vehicles/motorcycle.svg", "en": "motorcycle", "nl": "motor" },
+		{ "key": "airplane", "src": "/assets/vehicles/airplane.svg", "en": "airplane", "nl": "vliegtuig" },
+		{ "key": "helicopter", "src": "/assets/vehicles/helicopter.svg", "en": "helicopter", "nl": "helikopter" },
+		{ "key": "boat", "src": "/assets/vehicles/boat.svg", "en": "boat", "nl": "boot" },
+		{ "key": "train", "src": "/assets/vehicles/train.svg", "en": "train", "nl": "trein" },
+		{ "key": "tractor", "src": "/assets/vehicles/tractor.svg", "en": "tractor", "nl": "tractor" }
+	]
+}


### PR DESCRIPTION
Add a new 'Vehicles' game mode, mirroring the structure of the 'Animals' mode, to provide an additional learning category.

---
<a href="https://cursor.com/background-agent?bcId=bc-93138b14-b7eb-474a-8fa9-c966865fe43a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-93138b14-b7eb-474a-8fa9-c966865fe43a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

